### PR TITLE
Add experimental OP-TEE (-optee) variant per board

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,9 +39,9 @@
 
   packageRules: [
     {
-      // Never build pre-releases (-rc) of U-Boot or ATF.
+      // Never build pre-releases (-rc) of U-Boot, ATF or OP-TEE.
       matchManagers: ['custom.regex'],
-      matchDepNames: ['u-boot', 'arm-trusted-firmware'],
+      matchDepNames: ['u-boot', 'arm-trusted-firmware', 'optee_os'],
       allowedVersions: '!/-rc/',
     },
   ],

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build ${{ matrix.board.title }}
+    name: Build ${{ matrix.board.title }}${{ matrix.variant.title }}
     # Only spend runner minutes on trusted PRs: Renovate, the repo owner, or a
     # PR explicitly labelled "build". Pushes to main and manual runs always build.
     if: >-
@@ -50,6 +50,13 @@ jobs:
           - title: Orange Pi 5 Plus
             name: orangepi5-plus
             defconfig: orangepi-5-plus-rk3588
+        variant:
+          - title: ""
+            suffix: ""
+            optee: "off"
+          - title: " + OP-TEE"
+            suffix: "-optee"
+            optee: "on"
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -67,19 +74,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ${{ matrix.board.title }}
+      - name: Build ${{ matrix.board.title }}${{ matrix.variant.title }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/arm64
           outputs: type=local,dest=./out
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.board.name }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.board.name }},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,ignore-error=true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.board.name }}-${{ matrix.variant.optee }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/buildcache:${{ matrix.board.name }}-${{ matrix.variant.optee }},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,ignore-error=true
           build-args: |
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
             BOARD=${{ matrix.board.name }}
             DEFCONFIG=${{ matrix.board.defconfig }}
+            NAME=u-boot-${{ matrix.board.name }}${{ matrix.variant.suffix }}-spi
+            OPTEE=${{ matrix.variant.optee }}
 
       - name: Attest build provenance
         if: github.event_name != 'pull_request'
@@ -90,7 +99,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: u-boot-${{ matrix.board.name }}
+          name: u-boot-${{ matrix.board.name }}${{ matrix.variant.suffix }}
           path: ./out/*
           if-no-files-found: error
 
@@ -126,6 +135,7 @@ jobs:
             echo "atf=$(jq -r '.atf_version' "$manifest")"
             echo "rkbin_ddr=$(jq -r '.rkbin_ddr_version' "$manifest")"
             echo "rkbin_ref=$(jq -r '.rkbin_ref' "$manifest")"
+            echo "optee=$(jq -rs 'map(.optee_version) | map(select(. != "none")) | (.[0] // "none")' artifacts/*.manifest.json)"
           } >> "$GITHUB_OUTPUT"
           echo "Releasing U-Boot $uboot"
 
@@ -157,6 +167,12 @@ jobs:
             | Arm Trusted Firmware (BL31) | ${{ steps.meta.outputs.atf }} |
             | Rockchip DDR blob (rkbin)   | ${{ steps.meta.outputs.rkbin_ddr }} |
             | rkbin commit | `${{ steps.meta.outputs.rkbin_ref }}` |
+            | OP-TEE (BL32, `-optee` variant only) | ${{ steps.meta.outputs.optee }} |
+
+            Two variants are published per board:
+
+            - `u-boot-<board>-spi.bin` — standard build (recommended).
+            - `u-boot-<board>-optee-spi.bin` — adds the OP-TEE secure world (BL32). Experimental: please test on your board before relying on it.
 
             **Verify a binary**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,14 @@
 ARG U_BOOT_VERSION=v2026.04
 # renovate: datasource=github-tags depName=arm-trusted-firmware packageName=ARM-software/arm-trusted-firmware versioning=loose
 ARG ATF_VERSION=v2.15.0
+# renovate: datasource=github-tags depName=optee_os packageName=OP-TEE/optee_os versioning=semver
+ARG OPTEE_VERSION=4.10.0
 # rkbin has no tags/releases, so it is pinned to an exact commit of `master`.
 # renovate: datasource=git-refs depName=rkbin packageName=https://github.com/rockchip-linux/rkbin currentValue=master
 ARG RKBIN_REF=ecb4fcbe954edf38b3ae037d5de6d9f5bccf81f4
+
+# OP-TEE secure-world (BL32) payload: "off" (default) or "on", selected per build.
+ARG OPTEE=off
 
 # ---------------------------------------------------------------------------
 # Base build environment. The base image is pinned by digest and kept current
@@ -80,6 +85,31 @@ RUN --mount=type=cache,target=/atf/src/build \
     cp build/rk3588/release/bl31/bl31.elf /atf/bl31.elf
 
 # ---------------------------------------------------------------------------
+# OP-TEE secure-world (BL32), built from source only when OPTEE=on. `tee-off`
+# is an empty placeholder so the default build never pulls in the OP-TEE stage.
+# ---------------------------------------------------------------------------
+FROM base AS tee-off
+RUN mkdir -p /optee
+
+FROM base AS tee-on
+ARG OPTEE_VERSION
+ARG OPTEE_SOURCE=https://github.com/OP-TEE/optee_os/archive/refs/tags/${OPTEE_VERSION}.tar.gz
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install --no-install-recommends -y python3-cryptography
+
+RUN mkdir -p /optee/src && \
+    curl -fsSL "${OPTEE_SOURCE}" | tar -xz -C /optee/src --strip-components=1
+
+WORKDIR /optee/src
+RUN make -j"$(nproc)" PLATFORM=rockchip-rk3588 CFG_ARM64_core=y CFG_USER_TA_TARGETS=ta_arm64 CROSS_COMPILE64= O=out && \
+    cp out/core/tee.elf /optee/tee.elf
+
+# Resolves to tee-off or tee-on depending on the OPTEE build arg.
+FROM tee-${OPTEE} AS tee
+
+# ---------------------------------------------------------------------------
 # U-Boot source
 # ---------------------------------------------------------------------------
 FROM base AS u-boot-source
@@ -96,6 +126,7 @@ FROM base AS u-boot-builder
 ARG U_BOOT_VERSION
 ARG ATF_VERSION
 ARG RKBIN_REF
+ARG OPTEE_VERSION
 ARG SOURCE_DATE_EPOCH
 
 ARG BOARD=orangepi5
@@ -105,6 +136,7 @@ ARG DEFCONFIG=orangepi-5-rk3588s
 COPY --from=u-boot-source /u-boot/src /u-boot/src
 COPY --from=rkbin /rkbin /rkbin
 COPY --from=arm-trusted-firmware /atf /atf
+COPY --from=tee /optee /optee
 
 ENV ROCKCHIP_TPL=/rkbin/tpl.bin
 ENV BL31=/atf/bl31.elf
@@ -112,8 +144,10 @@ ENV ARCH=arm64
 # Honour reproducible-builds timestamp inside U-Boot itself.
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 
+# When OP-TEE was built (OPTEE=on), /optee/tee.elf exists and is fed to binman.
 WORKDIR /u-boot/src
 RUN --mount=type=cache,target=/u-boot/build \
+    if [ -f /optee/tee.elf ]; then export TEE=/optee/tee.elf; fi && \
     make O=/u-boot/build -j"$(nproc)" "${DEFCONFIG}_defconfig" && \
     make O=/u-boot/build -j"$(nproc)" HOSTLDLIBS_mkimage="-lssl -lcrypto"
 
@@ -121,8 +155,9 @@ WORKDIR /u-boot
 RUN --mount=type=cache,target=/u-boot/build \
     mkdir -p out && \
     cp build/u-boot-rockchip-spi.bin "out/${NAME}.bin" && \
-    printf '{\n  "board": "%s",\n  "u_boot_version": "%s",\n  "atf_version": "%s",\n  "rkbin_ref": "%s",\n  "rkbin_ddr_version": "v%s",\n  "source_date_epoch": "%s"\n}\n' \
-      "${BOARD}" "${U_BOOT_VERSION}" "${ATF_VERSION}" "${RKBIN_REF}" "$(cat /rkbin/ddr.version)" "${SOURCE_DATE_EPOCH}" \
+    if [ -f /optee/tee.elf ]; then optee="${OPTEE_VERSION}"; else optee="none"; fi && \
+    printf '{\n  "board": "%s",\n  "u_boot_version": "%s",\n  "atf_version": "%s",\n  "rkbin_ref": "%s",\n  "rkbin_ddr_version": "v%s",\n  "optee_version": "%s",\n  "source_date_epoch": "%s"\n}\n' \
+      "${BOARD}" "${U_BOOT_VERSION}" "${ATF_VERSION}" "${RKBIN_REF}" "$(cat /rkbin/ddr.version)" "${optee}" "${SOURCE_DATE_EPOCH}" \
       > "out/${NAME}.manifest.json"
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ wget https://github.com/schneid-l/u-boot-orangepi5/releases/latest/download/u-bo
 wget https://github.com/schneid-l/u-boot-orangepi5/releases/latest/download/u-boot-orangepi5-plus-spi.bin
 ```
 
+> [!NOTE]
+> An **experimental `-optee` variant** is published next to each board (e.g. `u-boot-orangepi5-optee-spi.bin`). It bundles the OP-TEE secure world (BL32, built from [OP-TEE OS](https://github.com/OP-TEE/optee_os)) for TrustZone-based features. The standard binary above is recommended; only use the `-optee` build if you need OP-TEE, and test it on your board first.
+
 We will assume that the SPI flash chip is `/dev/mtdblock0` (you can check this by using `lsblk`).
 
 Reset the SPI flash:
@@ -111,6 +114,8 @@ Available build args:
 - `U_BOOT_VERSION`: the U-Boot release tag to build (default: latest stable, kept up to date by Renovate)
 - `ATF_VERSION`: the ARM Trusted Firmware release tag (default: latest stable, kept up to date by Renovate)
 - `RKBIN_REF`: the rkbin commit to pull the Rockchip DDR/TPL blob from (default: a pinned `master` commit, kept up to date by Renovate)
+- `OPTEE`: set to `on` to build and bundle the OP-TEE secure world (BL32); `off` by default
+- `OPTEE_VERSION`: the [OP-TEE OS](https://github.com/OP-TEE/optee_os) release to build when `OPTEE=on` (default: latest stable, kept up to date by Renovate)
 - `DEFCONFIG`: the U-Boot defconfig to use (`_defconfig` is automatically appended, default: `orangepi-5-rk3588s`)
 - `BOARD`: the board name, used in the output filename (default: `orangepi5`)
 - `NAME`: the binary output name (default: `u-boot-${BOARD}-spi`)


### PR DESCRIPTION
Adds an **experimental `-optee` variant** per board, addressing the only substantive build warning (binman's `missing optional external blobs ... tee-os`).

## What
- The rkbin `bl32` blob is **not** compatible with mainline u-boot binman (it's Rockchip's raw format, not the OP-TEE ELF — binman fails with `Magic number does not match`). So OP-TEE OS is **built from source** (`OP-TEE/optee_os`, `PLATFORM=rockchip-rk3588`) and fed to binman as `tee.elf`.
- A `tee-on`/`tee-off` selector stage means the **default build never even builds OP-TEE** — its binary stays byte-identical (verified: same SHA256 as the current `v2026.04` release).
- The build matrix gains an `optee` dimension → each board ships two binaries:
  - `u-boot-<board>-spi.bin` — standard (recommended), unchanged.
  - `u-boot-<board>-optee-spi.bin` — bundles OP-TEE BL32 (~2 MB vs ~1.5 MB).
- `OPTEE_VERSION` is tracked by Renovate (semver, `-rc` excluded); the manifest records `optee_version`; the release notes list the variants + OP-TEE version.

## Verification (all built locally on arm64)
| Build | Result |
| --- | --- |
| orangepi5 / off | 1.5 MB — **byte-identical** to the released binary |
| orangepi5 / on | 2.1 MB — no binman warning, OP-TEE bundled |
| orangepi5-plus / off | builds clean |
| orangepi5-plus / on | 2.0 MB — OP-TEE bundled |

`actionlint` clean, `renovate-config-validator` passes.

> [!NOTE]
> The `-optee` binaries can't be boot-tested in CI, hence "experimental". The default binaries are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
